### PR TITLE
Prevent empty string iterator dereference

### DIFF
--- a/include/boost/convert/base.hpp
+++ b/include/boost/convert/base.hpp
@@ -102,6 +102,7 @@ struct boost::cnv::cnvbase
     void
     str_to_(string_type const& str, optional<out_type>& result_out) const
     {
+        if (str.empty()) return;
         cnv::range<string_type const> range (str);
 
         /**/ if (skipws_) for (; std::isspace(*range.begin()); ++range);


### PR DESCRIPTION
https://svn.boost.org/trac/boost/ticket/11792

Not sure if `empty()` is available for any `string_type`. Also not sure if doing a pull request here is the right place to submit a fix.