### PR TITLE
Support more types

### DIFF
--- a/include/boost/convert/base.hpp
+++ b/include/boost/convert/base.hpp
@@ -55,25 +55,29 @@ struct boost::cnv::cnvbase
     }
 
     // Basic type to string
-    BOOST_CNV_TO_STRING (  int_type v, optional<string_type>& r) const { to_str_(v, r); }
-    BOOST_CNV_TO_STRING ( uint_type v, optional<string_type>& r) const { to_str_(v, r); }
-    BOOST_CNV_TO_STRING ( lint_type v, optional<string_type>& r) const { to_str_(v, r); }
-    BOOST_CNV_TO_STRING (ulint_type v, optional<string_type>& r) const { to_str_(v, r); }
-    BOOST_CNV_TO_STRING ( sint_type v, optional<string_type>& r) const { to_str_(v, r); }
-    BOOST_CNV_TO_STRING (usint_type v, optional<string_type>& r) const { to_str_(v, r); }
-    BOOST_CNV_TO_STRING (  flt_type v, optional<string_type>& r) const { to_str_(v, r); }
-    BOOST_CNV_TO_STRING (  dbl_type v, optional<string_type>& r) const { to_str_(v, r); }
-    BOOST_CNV_TO_STRING ( ldbl_type v, optional<string_type>& r) const { to_str_(v, r); }
+    BOOST_CNV_TO_STRING (   int_type v, optional<string_type>& r) const { to_str_(v, r); }
+    BOOST_CNV_TO_STRING (  uint_type v, optional<string_type>& r) const { to_str_(v, r); }
+    BOOST_CNV_TO_STRING (  lint_type v, optional<string_type>& r) const { to_str_(v, r); }
+    BOOST_CNV_TO_STRING ( llint_type v, optional<string_type>& r) const { to_str_(v, r); }
+    BOOST_CNV_TO_STRING ( ulint_type v, optional<string_type>& r) const { to_str_(v, r); }
+    BOOST_CNV_TO_STRING (ullint_type v, optional<string_type>& r) const { to_str_(v, r); }
+    BOOST_CNV_TO_STRING (  sint_type v, optional<string_type>& r) const { to_str_(v, r); }
+    BOOST_CNV_TO_STRING ( usint_type v, optional<string_type>& r) const { to_str_(v, r); }
+    BOOST_CNV_TO_STRING (   flt_type v, optional<string_type>& r) const { to_str_(v, r); }
+    BOOST_CNV_TO_STRING (   dbl_type v, optional<string_type>& r) const { to_str_(v, r); }
+    BOOST_CNV_TO_STRING (  ldbl_type v, optional<string_type>& r) const { to_str_(v, r); }
     // String to basic type
-    BOOST_CNV_STRING_TO (string_type const& s, optional<  int_type>& r) const { str_to_(s, r); }
-    BOOST_CNV_STRING_TO (string_type const& s, optional< uint_type>& r) const { str_to_(s, r); }
-    BOOST_CNV_STRING_TO (string_type const& s, optional< lint_type>& r) const { str_to_(s, r); }
-    BOOST_CNV_STRING_TO (string_type const& s, optional<ulint_type>& r) const { str_to_(s, r); }
-    BOOST_CNV_STRING_TO (string_type const& s, optional< sint_type>& r) const { str_to_(s, r); }
-    BOOST_CNV_STRING_TO (string_type const& s, optional<usint_type>& r) const { str_to_(s, r); }
-    BOOST_CNV_STRING_TO (string_type const& s, optional<  flt_type>& r) const { str_to_(s, r); }
-    BOOST_CNV_STRING_TO (string_type const& s, optional<  dbl_type>& r) const { str_to_(s, r); }
-    BOOST_CNV_STRING_TO (string_type const& s, optional< ldbl_type>& r) const { str_to_(s, r); }
+    BOOST_CNV_STRING_TO (string_type const& s, optional<   int_type>& r) const { str_to_(s, r); }
+    BOOST_CNV_STRING_TO (string_type const& s, optional<  uint_type>& r) const { str_to_(s, r); }
+    BOOST_CNV_STRING_TO (string_type const& s, optional<  lint_type>& r) const { str_to_(s, r); }
+    BOOST_CNV_STRING_TO (string_type const& s, optional< llint_type>& r) const { str_to_(s, r); }
+    BOOST_CNV_STRING_TO (string_type const& s, optional< ulint_type>& r) const { str_to_(s, r); }
+    BOOST_CNV_STRING_TO (string_type const& s, optional<ullint_type>& r) const { str_to_(s, r); }
+    BOOST_CNV_STRING_TO (string_type const& s, optional<  sint_type>& r) const { str_to_(s, r); }
+    BOOST_CNV_STRING_TO (string_type const& s, optional< usint_type>& r) const { str_to_(s, r); }
+    BOOST_CNV_STRING_TO (string_type const& s, optional<   flt_type>& r) const { str_to_(s, r); }
+    BOOST_CNV_STRING_TO (string_type const& s, optional<   dbl_type>& r) const { str_to_(s, r); }
+    BOOST_CNV_STRING_TO (string_type const& s, optional<  ldbl_type>& r) const { str_to_(s, r); }
     // Formatters
 //  BOOST_CNV_PARAM (locale,  std::locale const) { locale_    = arg[ARG::   locale]; return dncast(); }
     BOOST_CNV_PARAM (base,     base::type const) { base_      = arg[ARG::     base]; return dncast(); }

--- a/include/boost/convert/spirit.hpp
+++ b/include/boost/convert/spirit.hpp
@@ -38,7 +38,7 @@ struct boost::cnv::spirit : public boost::cnv::cnvbase<boost::cnv::spirit>
                 result_out = result;
     }
     template<typename in_type, typename char_type>
-    cnv::range<char*>
+    cnv::range<char_type*>
     to_str(in_type value_in, char_type* beg) const
     {
         typedef typename boost::spirit::traits::create_generator<in_type>::type generator;
@@ -46,7 +46,7 @@ struct boost::cnv::spirit : public boost::cnv::cnvbase<boost::cnv::spirit>
         char_type* end = beg;
         bool      good = boost::spirit::karma::generate(end, generator(), value_in);
         
-        return cnv::range<char*>(beg, good ? end : beg);
+        return cnv::range<char_type*>(beg, good ? end : beg);
     }
 };
 

--- a/include/boost/convert/strtol.hpp
+++ b/include/boost/convert/strtol.hpp
@@ -55,17 +55,21 @@ struct boost::cnv::strtol : public boost::cnv::cnvbase<boost::cnv::strtol>
     template<typename string_type> void str_to(cnv::range<string_type> v, optional<   int_type>& r) const { str_to_i (v, r); }
     template<typename string_type> void str_to(cnv::range<string_type> v, optional<  sint_type>& r) const { str_to_i (v, r); }
     template<typename string_type> void str_to(cnv::range<string_type> v, optional<  lint_type>& r) const { str_to_i (v, r); }
+    template<typename string_type> void str_to(cnv::range<string_type> v, optional< llint_type>& r) const { str_to_i (v, r); }
     template<typename string_type> void str_to(cnv::range<string_type> v, optional<  uint_type>& r) const { str_to_i (v, r); }
     template<typename string_type> void str_to(cnv::range<string_type> v, optional< usint_type>& r) const { str_to_i (v, r); }
     template<typename string_type> void str_to(cnv::range<string_type> v, optional< ulint_type>& r) const { str_to_i (v, r); }
+    template<typename string_type> void str_to(cnv::range<string_type> v, optional<ullint_type>& r) const { str_to_i (v, r); }
     template<typename string_type> void str_to(cnv::range<string_type> v, optional<   flt_type>& r) const { str_to_d (v, r); }
     template<typename string_type> void str_to(cnv::range<string_type> v, optional<   dbl_type>& r) const { str_to_d (v, r); }
     template<typename string_type> void str_to(cnv::range<string_type> v, optional<  ldbl_type>& r) const { str_to_d (v, r); }
 
-    template <typename char_type> cnv::range<char_type*> to_str (  int_type v, char_type* buf) const { return i_to_str(v, buf); }
-    template <typename char_type> cnv::range<char_type*> to_str ( uint_type v, char_type* buf) const { return ui_to_str(v, buf); }
-    template <typename char_type> cnv::range<char_type*> to_str ( lint_type v, char_type* buf) const { return i_to_str(v, buf); }
-    template <typename char_type> cnv::range<char_type*> to_str (ulint_type v, char_type* buf) const { return ui_to_str(v, buf); }
+    template <typename char_type> cnv::range<char_type*> to_str (   int_type v, char_type* buf) const { return i_to_str(v, buf); }
+    template <typename char_type> cnv::range<char_type*> to_str (  uint_type v, char_type* buf) const { return ui_to_str(v, buf); }
+    template <typename char_type> cnv::range<char_type*> to_str (  lint_type v, char_type* buf) const { return i_to_str(v, buf); }
+    template <typename char_type> cnv::range<char_type*> to_str ( ulint_type v, char_type* buf) const { return ui_to_str(v, buf); }
+    template <typename char_type> cnv::range<char_type*> to_str ( llint_type v, char_type* buf) const { return i_to_str(v, buf); }
+    template <typename char_type> cnv::range<char_type*> to_str (ullint_type v, char_type* buf) const { return ui_to_str(v, buf); }
     template <typename char_type> cnv::range<char_type*> to_str ( dbl_type v, char_type* buf) const;
 
     template<typename char_type, typename in_type> cnv::range<char_type*> i_to_str (in_type, char_type*) const;

--- a/include/boost/convert/strtol.hpp
+++ b/include/boost/convert/strtol.hpp
@@ -62,11 +62,14 @@ struct boost::cnv::strtol : public boost::cnv::cnvbase<boost::cnv::strtol>
     template<typename string_type> void str_to(cnv::range<string_type> v, optional<   dbl_type>& r) const { str_to_d (v, r); }
     template<typename string_type> void str_to(cnv::range<string_type> v, optional<  ldbl_type>& r) const { str_to_d (v, r); }
 
-    template <typename char_type> cnv::range<char_type*> to_str ( int_type v, char_type* buf) const { return i_to_str(v, buf); }
-    template <typename char_type> cnv::range<char_type*> to_str (lint_type v, char_type* buf) const { return i_to_str(v, buf); }
+    template <typename char_type> cnv::range<char_type*> to_str (  int_type v, char_type* buf) const { return i_to_str(v, buf); }
+    template <typename char_type> cnv::range<char_type*> to_str ( uint_type v, char_type* buf) const { return ui_to_str(v, buf); }
+    template <typename char_type> cnv::range<char_type*> to_str ( lint_type v, char_type* buf) const { return i_to_str(v, buf); }
+    template <typename char_type> cnv::range<char_type*> to_str (ulint_type v, char_type* buf) const { return ui_to_str(v, buf); }
     template <typename char_type> cnv::range<char_type*> to_str ( dbl_type v, char_type* buf) const;
 
     template<typename char_type, typename in_type> cnv::range<char_type*> i_to_str (in_type, char_type*) const;
+    template<typename char_type, typename in_type> cnv::range<char_type*> ui_to_str (in_type, char_type*) const;
     template<typename string_type, typename out_type> void                str_to_i (cnv::range<string_type>, optional<out_type>&) const;
     template<typename string_type, typename out_type> void                str_to_d (cnv::range<string_type>, optional<out_type>&) const;
 
@@ -89,6 +92,21 @@ boost::cnv::strtol::i_to_str(Type value, char_type* buf) const
 
     if (beg == end)  *(--beg) = '0';
     if (is_negative) *(--beg) = '-';
+
+    return cnv::range<char_type*>(beg, end);
+}
+
+template<typename char_type, typename Type>
+boost::cnv::range<char_type*>
+boost::cnv::strtol::ui_to_str(Type value, char_type* buf) const
+{
+    char_type*         beg = buf + bufsize_ / 2;
+    char_type*         end = beg;
+
+    if (base_ == 10) for (; value; *(--beg) = int(value % 10) + '0', value /= 10);
+    else             for (; value; *(--beg) = get_char(value % base_), value /= base_);
+
+    if (beg == end)  *(--beg) = '0';
 
     return cnv::range<char_type*>(beg, end);
 }

--- a/test/spirit_converter.cpp
+++ b/test/spirit_converter.cpp
@@ -15,6 +15,7 @@ int main(int, char const* []) { return 0; }
 #include <cstdio>
 
 using std::string;
+using std::wstring;
 using boost::convert;
 
 namespace cnv = boost::cnv;
@@ -27,31 +28,48 @@ main(int, char const* [])
 {
     char const* const   c_stri ("12345");
     char const* const   c_strd ("123.45");
+    wchar_t const* const c_wstri (L"12345");
+    wchar_t const* const c_wstrd (L"123.45");
     std::string const std_stri (c_stri);
     std::string const std_strd (c_strd);
+    std::wstring const std_wstri (c_wstri);
+    std::wstring const std_wstrd (c_wstrd);
     my_string const    my_stri (c_stri, c_stri + strlen(c_stri));
     my_string const    my_strd (c_strd, c_strd + strlen(c_strd));
 
     boost::cnv::spirit cnv;
 
-    BOOST_TEST( 12345 == convert<     int>(  c_stri).value());
-    BOOST_TEST( 12345 == convert<     int>(std_stri).value());
-    BOOST_TEST( 12345 == convert<     int>( my_stri).value());
-    BOOST_TEST( 12345 == convert<long int>(  c_stri).value());
-    BOOST_TEST( 12345 == convert<long int>(std_stri).value());
-    BOOST_TEST( 12345 == convert<long int>( my_stri).value());
-    BOOST_TEST(123.45 == convert<  double>(  c_strd).value());
-//  BOOST_TEST(123.45 == convert<  double>(std_strd).value());
-    BOOST_TEST(123.45 == convert<  double>( my_strd).value());
+    BOOST_TEST( 12345 == convert<     int>(   c_stri).value());
+    BOOST_TEST( 12345 == convert<     int>(  c_wstri).value());
+    BOOST_TEST( 12345 == convert<     int>( std_stri).value());
+    BOOST_TEST( 12345 == convert<     int>(std_wstri).value());
+    BOOST_TEST( 12345 == convert<     int>(  my_stri).value());
+    BOOST_TEST( 12345 == convert<long int>(   c_stri).value());
+    BOOST_TEST( 12345 == convert<long int>(  c_wstri).value());
+    BOOST_TEST( 12345 == convert<long int>( std_stri).value());
+    BOOST_TEST( 12345 == convert<long int>(std_wstri).value());
+    BOOST_TEST( 12345 == convert<long int>(  my_stri).value());
+    BOOST_TEST(123.45 == convert<  double>(   c_strd).value());
+    BOOST_TEST(123.45 == convert<  double>(  c_wstrd).value());
+//  BOOST_TEST(123.45 == convert<  double>( std_strd).value());
+//  BOOST_TEST(123.45 == convert<  double>(std_wstrd).value());
+    BOOST_TEST(123.45 == convert<  double>(  my_strd).value());
 
     BOOST_TEST(!convert<   int>("uhm"));
+    BOOST_TEST(!convert<   int>(L"uhm"));
     BOOST_TEST(!convert<double>("12.uhm"));
+    BOOST_TEST(!convert<double>("L12.uhm"));
 
-    BOOST_TEST( "1234" == convert<string>(1234).value());
-    BOOST_TEST("12xxx" == convert<string>(12, cnv(arg::width = 5)
-                                                 (arg::fill = 'x')
-                                                 (arg::adjust = cnv::adjust::left)).value());
-    BOOST_TEST("x12xx" == convert<string>(12, cnv(arg::adjust = cnv::adjust::center)).value());
+    BOOST_TEST(  "1234" == convert<string>(1234).value());
+    BOOST_TEST( L"1234" == convert<wstring>(1234).value());
+    BOOST_TEST( "12xxx" == convert<string>(12, cnv(arg::width = 5)
+                                                  (arg::fill = 'x')
+                                                  (arg::adjust = cnv::adjust::left)).value());
+    BOOST_TEST(L"12xxx" == convert<wstring>(12, cnv(arg::width = 5)
+                                                   (arg::fill = 'x')
+                                                   (arg::adjust = cnv::adjust::left)).value());
+    BOOST_TEST( "x12xx" == convert<string>(12, cnv(arg::adjust = cnv::adjust::center)).value());
+    BOOST_TEST(L"x12xx" == convert<wstring>(12, cnv(arg::adjust = cnv::adjust::center)).value());
 
 //    BOOST_TEST("12.34" == convert<std::string>(12.34).value());
 //    printf("%s\n", convert<std::string>(12.34).value().c_str());

--- a/test/spirit_converter.cpp
+++ b/test/spirit_converter.cpp
@@ -44,11 +44,13 @@ main(int, char const* [])
     BOOST_TEST( 12345 == convert<     int>( std_stri).value());
     BOOST_TEST( 12345 == convert<     int>(std_wstri).value());
     BOOST_TEST( 12345 == convert<     int>(  my_stri).value());
+    BOOST_TEST( 12345 == convert<unsigned int>(c_stri).value());
     BOOST_TEST( 12345 == convert<long int>(   c_stri).value());
     BOOST_TEST( 12345 == convert<long int>(  c_wstri).value());
     BOOST_TEST( 12345 == convert<long int>( std_stri).value());
     BOOST_TEST( 12345 == convert<long int>(std_wstri).value());
     BOOST_TEST( 12345 == convert<long int>(  my_stri).value());
+    BOOST_TEST( 12345 == convert<unsigned long int>(c_stri).value());
     BOOST_TEST(123.45 == convert<  double>(   c_strd).value());
     BOOST_TEST(123.45 == convert<  double>(  c_wstrd).value());
 //  BOOST_TEST(123.45 == convert<  double>( std_strd).value());
@@ -61,6 +63,7 @@ main(int, char const* [])
     BOOST_TEST(!convert<double>("L12.uhm"));
 
     BOOST_TEST(  "1234" == convert<string>(1234).value());
+    BOOST_TEST(  "1234" == convert<string>(1234u).value());
     BOOST_TEST( L"1234" == convert<wstring>(1234).value());
     BOOST_TEST( "12xxx" == convert<string>(12, cnv(arg::width = 5)
                                                   (arg::fill = 'x')

--- a/test/spirit_converter.cpp
+++ b/test/spirit_converter.cpp
@@ -51,6 +51,8 @@ main(int, char const* [])
     BOOST_TEST( 12345 == convert<long int>(std_wstri).value());
     BOOST_TEST( 12345 == convert<long int>(  my_stri).value());
     BOOST_TEST( 12345 == convert<unsigned long int>(c_stri).value());
+    BOOST_TEST( 12345 == convert<long long int>(c_stri).value());
+    BOOST_TEST( 12345 == convert<unsigned long long int>(c_stri).value());
     BOOST_TEST(123.45 == convert<  double>(   c_strd).value());
     BOOST_TEST(123.45 == convert<  double>(  c_wstrd).value());
 //  BOOST_TEST(123.45 == convert<  double>( std_strd).value());
@@ -64,6 +66,8 @@ main(int, char const* [])
 
     BOOST_TEST(  "1234" == convert<string>(1234).value());
     BOOST_TEST(  "1234" == convert<string>(1234u).value());
+    BOOST_TEST(  "1234" == convert<string>(1234ll).value());
+    BOOST_TEST(  "1234" == convert<string>(1234ull).value());
     BOOST_TEST( L"1234" == convert<wstring>(1234).value());
     BOOST_TEST( "12xxx" == convert<string>(12, cnv(arg::width = 5)
                                                   (arg::fill = 'x')

--- a/test/strtol_converter.cpp
+++ b/test/strtol_converter.cpp
@@ -80,56 +80,71 @@ static
 void
 test_int_to_str()
 {
-    short const s_int = -123;
-    int const   i_int = -123;
-    long const  l_int = -123;
+    short const      s_int = -123;
+    int const        i_int = -123;
+    long const       l_int = -123;
+    long long const ll_int = -123;
 
     BOOST_TEST( "-123" == convert< std::string> ( s_int).value());
     BOOST_TEST( "-123" == convert< std::string> ( i_int).value());
     BOOST_TEST( "-123" == convert< std::string> ( l_int).value());
+    BOOST_TEST( "-123" == convert< std::string> (ll_int).value());
 
     BOOST_TEST(L"-123" == convert<std::wstring> ( s_int).value());
     BOOST_TEST(L"-123" == convert<std::wstring> ( i_int).value());
     BOOST_TEST(L"-123" == convert<std::wstring> ( l_int).value());
+    BOOST_TEST(L"-123" == convert<std::wstring> (ll_int).value());
 
-    unsigned int const      imin = (std::numeric_limits<int>::min)();
-    unsigned int const      imax = (std::numeric_limits<int>::max)();
-    unsigned long int const lmin = (std::numeric_limits<long int>::min)();
-    unsigned long int const lmax = (std::numeric_limits<long int>::max)();
+    unsigned int const            imin = (std::numeric_limits<int>::min)();
+    unsigned int const            imax = (std::numeric_limits<int>::max)();
+    unsigned long int const       lmin = (std::numeric_limits<long int>::min)();
+    unsigned long int const       lmax = (std::numeric_limits<long int>::max)();
+    unsigned long long int const llmin = (std::numeric_limits<long long int>::min)();
+    unsigned long long int const llmax = (std::numeric_limits<long long int>::max)();
     std::string const   imin_str = boost::lexical_cast<std::string>(imin);
     std::string const   imax_str = boost::lexical_cast<std::string>(imax);
     std::string const   lmin_str = boost::lexical_cast<std::string>(lmin);
     std::string const   lmax_str = boost::lexical_cast<std::string>(lmax);
+    std::string const  llmin_str = boost::lexical_cast<std::string>(llmin);
+    std::string const  llmax_str = boost::lexical_cast<std::string>(llmax);
 
-    BOOST_TEST(imin_str == convert<std::string> (imin).value());
-    BOOST_TEST(imax_str == convert<std::string> (imax).value());
-    BOOST_TEST(lmin_str == convert<std::string> (lmin).value());
-    BOOST_TEST(lmax_str == convert<std::string> (lmax).value());
+    BOOST_TEST( imin_str == convert<std::string> ( imin).value());
+    BOOST_TEST( imax_str == convert<std::string> ( imax).value());
+    BOOST_TEST( lmin_str == convert<std::string> ( lmin).value());
+    BOOST_TEST( lmax_str == convert<std::string> ( lmax).value());
+    BOOST_TEST(llmin_str == convert<std::string> (llmin).value());
+    BOOST_TEST(llmax_str == convert<std::string> (llmax).value());
 }
 
 static
 void
 test_uint_to_str()
 {
-    unsigned short const us_int = 123;
-    unsigned int const   ui_int = 123;
-    unsigned long const  ul_int = 123;
+    unsigned short const      us_int = 123;
+    unsigned int const        ui_int = 123;
+    unsigned long const       ul_int = 123;
+    unsigned long long const ull_int = 123;
 
-    BOOST_TEST( "123" == convert< std::string> (us_int).value());
-    BOOST_TEST( "123" == convert< std::string> (ui_int).value());
-    BOOST_TEST( "123" == convert< std::string> (ul_int).value());
+    BOOST_TEST( "123" == convert< std::string> ( us_int).value());
+    BOOST_TEST( "123" == convert< std::string> ( ui_int).value());
+    BOOST_TEST( "123" == convert< std::string> ( ul_int).value());
+    BOOST_TEST( "123" == convert< std::string> (ull_int).value());
 
-    BOOST_TEST(L"123" == convert<std::wstring> (us_int).value());
-    BOOST_TEST(L"123" == convert<std::wstring> (ui_int).value());
-    BOOST_TEST(L"123" == convert<std::wstring> (ul_int).value());
+    BOOST_TEST(L"123" == convert<std::wstring> ( us_int).value());
+    BOOST_TEST(L"123" == convert<std::wstring> ( ui_int).value());
+    BOOST_TEST(L"123" == convert<std::wstring> ( ul_int).value());
+    BOOST_TEST(L"123" == convert<std::wstring> (ull_int).value());
 
-    unsigned int const      uimax = (std::numeric_limits<unsigned int>::max)();
-    unsigned long int const ulmax = (std::numeric_limits<unsigned long int>::max)();
-    std::string const   uimax_str = boost::lexical_cast<std::string>(uimax);
-    std::string const   ulmax_str = boost::lexical_cast<std::string>(ulmax);
+    unsigned int const            uimax = (std::numeric_limits<unsigned int>::max)();
+    unsigned long int const       ulmax = (std::numeric_limits<unsigned long int>::max)();
+    unsigned long long int const ullmax = (std::numeric_limits<unsigned long long int>::max)();
+    std::string const   uimax_str = boost::lexical_cast<std::string>( uimax);
+    std::string const   ulmax_str = boost::lexical_cast<std::string>( ulmax);
+    std::string const  ullmax_str = boost::lexical_cast<std::string>(ullmax);
 
-    BOOST_TEST(uimax_str == convert<std::string> (uimax).value());
-    BOOST_TEST(ulmax_str == convert<std::string> (ulmax).value());
+    BOOST_TEST( uimax_str == convert<std::string> ( uimax).value());
+    BOOST_TEST( ulmax_str == convert<std::string> ( ulmax).value());
+    BOOST_TEST(ullmax_str == convert<std::string> (ullmax).value());
 }
 
 //[strtol_numeric_base_header

--- a/test/strtol_converter.cpp
+++ b/test/strtol_converter.cpp
@@ -76,6 +76,62 @@ test_str_to_int()
     BOOST_TEST(-12 == convert<int>(  wc_str).value());
 }
 
+static
+void
+test_int_to_str()
+{
+    short const s_int = -123;
+    int const   i_int = -123;
+    long const  l_int = -123;
+
+    BOOST_TEST( "-123" == convert< std::string> ( s_int).value());
+    BOOST_TEST( "-123" == convert< std::string> ( i_int).value());
+    BOOST_TEST( "-123" == convert< std::string> ( l_int).value());
+
+    BOOST_TEST(L"-123" == convert<std::wstring> ( s_int).value());
+    BOOST_TEST(L"-123" == convert<std::wstring> ( i_int).value());
+    BOOST_TEST(L"-123" == convert<std::wstring> ( l_int).value());
+
+    unsigned int const      imin = (std::numeric_limits<int>::min)();
+    unsigned int const      imax = (std::numeric_limits<int>::max)();
+    unsigned long int const lmin = (std::numeric_limits<long int>::min)();
+    unsigned long int const lmax = (std::numeric_limits<long int>::max)();
+    std::string const   imin_str = boost::lexical_cast<std::string>(imin);
+    std::string const   imax_str = boost::lexical_cast<std::string>(imax);
+    std::string const   lmin_str = boost::lexical_cast<std::string>(lmin);
+    std::string const   lmax_str = boost::lexical_cast<std::string>(lmax);
+
+    BOOST_TEST(imin_str == convert<std::string> (imin).value());
+    BOOST_TEST(imax_str == convert<std::string> (imax).value());
+    BOOST_TEST(lmin_str == convert<std::string> (lmin).value());
+    BOOST_TEST(lmax_str == convert<std::string> (lmax).value());
+}
+
+static
+void
+test_uint_to_str()
+{
+    unsigned short const us_int = 123;
+    unsigned int const   ui_int = 123;
+    unsigned long const  ul_int = 123;
+
+    BOOST_TEST( "123" == convert< std::string> (us_int).value());
+    BOOST_TEST( "123" == convert< std::string> (ui_int).value());
+    BOOST_TEST( "123" == convert< std::string> (ul_int).value());
+
+    BOOST_TEST(L"123" == convert<std::wstring> (us_int).value());
+    BOOST_TEST(L"123" == convert<std::wstring> (ui_int).value());
+    BOOST_TEST(L"123" == convert<std::wstring> (ul_int).value());
+
+    unsigned int const      uimax = (std::numeric_limits<unsigned int>::max)();
+    unsigned long int const ulmax = (std::numeric_limits<unsigned long int>::max)();
+    std::string const   uimax_str = boost::lexical_cast<std::string>(uimax);
+    std::string const   ulmax_str = boost::lexical_cast<std::string>(ulmax);
+
+    BOOST_TEST(uimax_str == convert<std::string> (uimax).value());
+    BOOST_TEST(ulmax_str == convert<std::string> (ulmax).value());
+}
+
 //[strtol_numeric_base_header
 #include <boost/convert.hpp>
 #include <boost/convert/strtol.hpp>
@@ -284,6 +340,8 @@ main(int, char const* [])
 
     test_str_to_int();
     test_str_to_uint();
+    test_int_to_str();
+    test_uint_to_str();
     test_base();
     test_skipws();
     test_dbl_to_str();


### PR DESCRIPTION
These changes add support for more conversion constellations:
* Allow spirit to write to wide (actually, any) strings
* Make strtol converter support converting unsigned types to strings
* Make spirit and strtol support 'long long' types