### PR TITLE
Fix strtol intmin

### DIFF
--- a/include/boost/convert/strtol.hpp
+++ b/include/boost/convert/strtol.hpp
@@ -82,13 +82,15 @@ struct boost::cnv::strtol : public boost::cnv::cnvbase<boost::cnv::strtol>
 
 template<typename char_type, typename Type>
 boost::cnv::range<char_type*>
-boost::cnv::strtol::i_to_str(Type value, char_type* buf) const
+boost::cnv::strtol::i_to_str(Type in_value, char_type* buf) const
 {
     // C1. Base=10 optimization improves performance 10%
 
+    typedef boost::make_unsigned<Type>::type unsigned_type;
     char_type*         beg = buf + bufsize_ / 2;
     char_type*         end = beg;
-    bool const is_negative = (value < 0) ? (value = -value, true) : false;
+    bool const is_negative = (in_value < 0);
+    unsigned_type value = static_cast<unsigned_type> (is_negative ? -in_value : in_value);
 
     if (base_ == 10) for (; value; *(--beg) = int(value % 10) + '0', value /= 10); //C1
     else             for (; value; *(--beg) = get_char(value % base_), value /= base_);

--- a/test/strtol_converter.cpp
+++ b/test/strtol_converter.cpp
@@ -95,12 +95,12 @@ test_int_to_str()
     BOOST_TEST(L"-123" == convert<std::wstring> ( l_int).value());
     BOOST_TEST(L"-123" == convert<std::wstring> (ll_int).value());
 
-    unsigned int const            imin = (std::numeric_limits<int>::min)();
-    unsigned int const            imax = (std::numeric_limits<int>::max)();
-    unsigned long int const       lmin = (std::numeric_limits<long int>::min)();
-    unsigned long int const       lmax = (std::numeric_limits<long int>::max)();
-    unsigned long long int const llmin = (std::numeric_limits<long long int>::min)();
-    unsigned long long int const llmax = (std::numeric_limits<long long int>::max)();
+    int const            imin = (std::numeric_limits<int>::min)();
+    int const            imax = (std::numeric_limits<int>::max)();
+    long int const       lmin = (std::numeric_limits<long int>::min)();
+    long int const       lmax = (std::numeric_limits<long int>::max)();
+    long long int const llmin = (std::numeric_limits<long long int>::min)();
+    long long int const llmax = (std::numeric_limits<long long int>::max)();
 
     std::string const   imin_str = boost::lexical_cast<std::string>(imin);
     std::string const   imax_str = boost::lexical_cast<std::string>(imax);


### PR DESCRIPTION
This fixes:
* A blooper where the strtol 'int_to_str' test didn't actually test int.
* strtol itself: minimum integer values were not handled correctly. (Which was obscured by above blooper).