### PR TITLE
Added missing include time.h

### DIFF
--- a/test/strtol_converter.cpp
+++ b/test/strtol_converter.cpp
@@ -22,6 +22,8 @@ int main(int, char const* []) { return 0; }
 #include <boost/convert.hpp>
 #include <boost/convert/strtol.hpp>
 
+#include <time.h>
+
 using std::string;
 using std::wstring;
 using boost::convert;


### PR DESCRIPTION
I'm guessing it worked on most platforms because \<ctime\> is included indirectly. But on Dinkumware on QNX, ::time() is not declared by \<ctime\>, only std::time() is.

Without this, the compiler gave an error for the ::time(0) call on line 256.