### PR TITLE
Mark function templates as inline

### DIFF
--- a/include/boost/convert/detail/char.hpp
+++ b/include/boost/convert/detail/char.hpp
@@ -24,15 +24,15 @@ namespace boost { namespace cnv
     }
     template <typename T> struct is_char : detail::is_char<typename boost::remove_const<T>::type> {};
 
-    template<typename char_type> bool      is_space(char_type);
-    template<typename char_type> char_type to_upper(char_type);
+    template<typename char_type> inline bool      is_space(char_type);
+    template<typename char_type> inline char_type to_upper(char_type);
 
-    template<> bool       is_space ( char_type c) { return bool(std::isspace(static_cast<uchar_type>(c))); }
-    template<> bool       is_space (uchar_type c) { return bool(std::isspace(c)); }
-    template<> bool       is_space (wchar_type c) { return bool(std::iswspace(c)); }
-    template<>  char_type to_upper ( char_type c) { return std::toupper(static_cast<uchar_type>(c)); }
-    template<> uchar_type to_upper (uchar_type c) { return std::toupper(c); }
-    template<> wchar_type to_upper (wchar_type c) { return std::towupper(c); }
+    template<> inline bool       is_space ( char_type c) { return bool(std::isspace(static_cast<uchar_type>(c))); }
+    template<> inline bool       is_space (uchar_type c) { return bool(std::isspace(c)); }
+    template<> inline bool       is_space (wchar_type c) { return bool(std::iswspace(c)); }
+    template<> inline  char_type to_upper ( char_type c) { return std::toupper(static_cast<uchar_type>(c)); }
+    template<> inline uchar_type to_upper (uchar_type c) { return std::toupper(c); }
+    template<> inline wchar_type to_upper (wchar_type c) { return std::towupper(c); }
 }}
 
 #endif // BOOST_CONVERT_DETAIL_IS_CHAR_HPP


### PR DESCRIPTION
... to avoid multiple definition linker errors when using them in
multiple translation units.