### PR TITLE
Update GitHub Actions CI file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
             buildtype: "boost"
             packages: "g++-5"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "g++-5"
             sources: ""
             llvm_os: ""
@@ -33,7 +34,8 @@ jobs:
             buildtype: "boost"
             packages: "g++-6"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "g++-6"
             sources: ""
             llvm_os: ""
@@ -45,7 +47,8 @@ jobs:
             buildtype: "boost"
             packages: "g++-6"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "g++-6"
             sources: ""
             llvm_os: ""
@@ -58,7 +61,8 @@ jobs:
             buildtype: "boost"
             packages: "g++-7"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "g++-7"
             sources: ""
             llvm_os: ""
@@ -70,7 +74,8 @@ jobs:
             buildtype: "boost"
             packages: "g++-7"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "g++-7"
             sources: ""
             llvm_os: ""
@@ -83,7 +88,8 @@ jobs:
             buildtype: "boost"
             packages: "g++-8"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "g++-8"
             sources: ""
             llvm_os: ""
@@ -95,7 +101,8 @@ jobs:
             buildtype: "boost"
             packages: "clang-3.5"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "clang++-3.5"
             sources: ""
             llvm_os: "precise"
@@ -107,7 +114,8 @@ jobs:
             buildtype: "boost"
             packages: "clang-3.6"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "clang++-3.6"
             sources: ""
             llvm_os: "precise"
@@ -119,7 +127,8 @@ jobs:
             buildtype: "boost"
             packages: "clang-3.7"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "clang++-3.7"
             sources: ""
             llvm_os: "precise"
@@ -131,7 +140,8 @@ jobs:
             buildtype: "boost"
             packages: "clang-3.8"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "clang++-3.8"
             sources: ""
             llvm_os: "precise"
@@ -143,7 +153,8 @@ jobs:
             buildtype: "boost"
             packages: "clang-3.9"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "clang++-3.9"
             sources: ""
             llvm_os: "precise"
@@ -155,7 +166,8 @@ jobs:
             buildtype: "boost"
             packages: "clang-4.0"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "clang++-4.0"
             sources: ""
             llvm_os: "xenial"
@@ -167,7 +179,8 @@ jobs:
             buildtype: "boost"
             packages: "clang-5.0"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "clang++-5.0"
             sources: ""
             llvm_os: "xenial"
@@ -179,7 +192,7 @@ jobs:
             buildtype: "boost"
             packages: "libstdc++-5-dev"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-18.04"
             cxx: "clang++"
             sources: ""
             llvm_os: ""
@@ -191,7 +204,7 @@ jobs:
             buildtype: "boost"
             packages: " libc++-9-dev libc++abi-9-dev"
             packages_to_remove: "libc++-dev libc++abi-dev"
-            os: "ubuntu-16.04"
+            os: "ubuntu-18.04"
             cxx: "clang++-libc++"
             sources: ""
             llvm_os: "xenial"
@@ -207,6 +220,16 @@ jobs:
       - name: Check if running in container
         if: matrix.container != ''
         run: echo "GHA_CONTAINER=${{ matrix.container }}" >> $GITHUB_ENV
+      - name: If running in container, upgrade packages
+        if: matrix.container != ''
+        run: |
+            apt-get -o Acquire::Retries=3 update && DEBIAN_FRONTEND=noninteractive apt-get -y install tzdata && apt-get -o Acquire::Retries=3 install -y sudo software-properties-common wget curl apt-transport-https make apt-file sudo unzip libssl-dev build-essential autotools-dev autoconf automake g++ libc++-helpers python ruby cpio gcc-multilib g++-multilib pkgconf python3 ccache libpython-dev
+            sudo apt-add-repository ppa:git-core/ppa
+            sudo apt-get -o Acquire::Retries=3 update && apt-get -o Acquire::Retries=3 -y install git
+            python_version=$(python3 -c 'import sys; print("{0.major}.{0.minor}".format(sys.version_info))')
+            sudo wget https://bootstrap.pypa.io/pip/$python_version/get-pip.py
+            sudo python3 get-pip.py
+            sudo /usr/local/bin/pip install cmake
 
       - uses: actions/checkout@v2
 
@@ -271,7 +294,7 @@ jobs:
 
           BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true
           cd ..
-          git clone -b $TRAVIS_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
+          git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
           cd boost-root
           git submodule update --init tools/boost_install
           git submodule update --init libs/headers
@@ -390,7 +413,7 @@ jobs:
 
           BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true
           cd ..
-          git clone -b $TRAVIS_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
+          git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
           cd boost-root
           git submodule update --init tools/boost_install
           git submodule update --init libs/headers


### PR DESCRIPTION
The Ubuntu 16.04 environment is scheduled to be removed from GitHub Actions in September 2021. Migrate those jobs to Docker containers or Ubuntu 18.04. Also, fix a problem with pip package installation on older platforms.