### PR TITLE
measure charconv performance

### DIFF
--- a/doc/performance.qbk
+++ b/doc/performance.qbk
@@ -11,30 +11,31 @@ The performance of ['Boost.Convert] depends entirely on the performance of the c
 
 In turn, the performance of every particular converter depends on the platform, the compiler used and the particular implementation of the underlying conversion component (`std::stream`, `printf`, ['Boost.Spirit], etc.). Consequently, the results below are only an approximate indication of ['relative] performance of the mentioned converters on the tested platforms. 
 
-When compiled with gcc-5.4.0 on 64-bit Ubuntu 16.04, tests produced the following results:
+When compiled with gcc-11.1.0 on 64-bit Ubuntu 16.04, tests produced the following results:
 
- str-to-int: spirit/strtol/lcast/scanf/stream= 0.27/ 0.35/  0.92/  2.11/  2.09 seconds.
- str-to-lng: spirit/strtol/lcast/scanf/stream= 0.69/ 0.31/  1.28/  2.07/  2.50 seconds.
- str-to-dbl: spirit/strtol/lcast/scanf/stream= 0.73/ 1.06/  7.95/  2.87/  5.10 seconds.
- int-to-str: spirit/strtol/lcast/prntf/stream= 1.96/ 1.39/  2.52/  3.49/  2.58 seconds.
- lng-to-str: spirit/strtol/lcast/prntf/stream= 2.45/ 1.51/  2.32/  3.30/  2.63 seconds.
- dbl-to-str: spirit/strtol/lcast/prntf/stream= 6.62/ 4.46/ 28.69/ 20.60/ 14.16 seconds.
+ str-to-int: spirit/strtol/lcast/scanf/stream/charconv=   0.23/   0.29/   3.64/   2.07/   1.69/   0.35 seconds.
+ str-to-lng: spirit/strtol/lcast/scanf/stream/charconv=   0.20/   0.37/   3.57/   2.09/   1.62/   0.21 seconds.
+ str-to-dbl: spirit/strtol/lcast/scanf/stream/charconv=   0.28/   0.96/   9.17/   2.64/   3.23/   1.87 seconds.
+ int-to-str: spirit/strtol/lcast/prntf/stream/charconv=   0.81/   0.47/   0.97/   2.17/   1.16/   0.47 seconds.
+ lng-to-str: spirit/strtol/lcast/prntf/stream/charconv=   0.78/   0.49/   1.16/   2.46/   1.22/   0.50 seconds.
+ dbl-to-str: spirit/strtol/lcast/prntf/stream/charconv=   2.15/   2.15/  21.00/  16.49/  10.62/   1.65 seconds.
 
 Based on the results, all things considered, I tend to conclude that there is no clear winner:
 
 * the ['Spirit.Qi]-based converter was the fastest for string to basic (`int`, `double`) conversions. So, it might be a good candidate for the tasks predominantly doing that kind of conversions (with ['Spirit.Qi] conversion-related limitations in mind); ['Spirit.Karma]'s ['to-string] performance did not seem as impressive;
+* the `charconv` converter was the fastest for basic to string conversions. The implementation of the opposite direction seems like it has a place for improvement.
 * the `std::iostream`-based converter was comparatively slow. Still, given its maturity, availability and formatting support, it might be an option to consider if conversion performance is not your primary concern;
 * the `strtol`-inspired converter was reasonably fast and with formatting support might be an attractive all-rounder. It should be noted that it is nowhere as mature as `boost::cnv::lexical_cast` or `boost::cnv::stream`. So, bugs are to be expected.
 
-For user-defined types `cnv::lexical_cast`, `cnv::cstream` and `cnv::strtol` were tested with the following results:
+For user-defined types `cnv::lexical_cast`, `cnv::cstream`, `cnv::strtol` and `cnv::charconv` were tested with the following results:
 
- str-to-user-type: lcast/stream/strtol=0.36/0.18/0.07 seconds.
- user-type-to-str: lcast/stream/strtol=0.58/0.09/0.06 seconds.
+ str-to-user-type: lcast/stream/strtol/charconv=0.21/0.08/0.03/0.03 seconds.
+ user-type-to-str: lcast/stream/strtol/charconv=0.17/0.04/0.02/0.01 seconds.
 
 To provide ['string-to-user-type] and ['user-type-to-string] conversions the first two deploy the same standard `std::iostream` library. However, `boost::cnv::cstream` considerably outperforms `boost::lexical_cast` in these tests. The results reflect different underlying designs. Namely,
 the standard ['Boost.Convert] deployment pattern is to create a converter or converters once and then re-use them. `boost::lexical_cast`, on the other hand, creates and then destroys a `std::stream` instance every time the function is called and the [@http://www.boost.org/doc/libs/1_55_0/doc/html/boost_lexical_cast/performance.html `boost::lexical_cast` performance] table indicates that the "std::stringstream ['with construction]" operation is considerably more expensive compared to "std::stringstream ['without construction]".
 
-`boost::cnv::strtol` support for user types has been implemented similarly but without the `std::stream`-related overhead. That resulted in the best out-of-three performance results.
+`boost::cnv::strtol` and `boost::cnv::charconv` support for user types has been implemented similarly but without the `std::stream`-related overhead. That resulted in better performance results.
 
 Based on the performance data, I tend to conclude that, given type-safety and benefits provided by the ['Boost.Convert] framework, it (with appropriate converters) should probably be the first choice for conversion-related tasks.
 
@@ -94,9 +95,10 @@ The class above is essentially a glorified 12-bytes character buffer sufficient 
 
 It produced the following relative results (compiled with `gcc -O3`):
 
- strtol int-to std::string/small-string: 1.41/0.53 seconds.
- spirit int-to std::string/small-string: 1.98/1.04 seconds.
- stream int-to std::string/small-string: 2.49/1.40 seconds.
+ strtol int-to std::string/small-string: 0.48/0.43 seconds.
+ spirit int-to std::string/small-string: 0.72/0.65 seconds.
+ stream int-to std::string/small-string: 1.24/1.11 seconds.
+ charconv int-to std::string/small-string: 0.52/0.47 seconds.
  
 The results suggest that for the projects that deal with string-related conversions and routinely deploy `std::string` facilities the conversion-related overhead will be outweighed by the overhead of `std::string`-related operations.
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,3 +17,17 @@ if(HAVE_BOOST_TEST)
     # these tests require C++17
     boost_test(TYPE run NAME convert_test_charconv_converter SOURCES charconv_converter.cpp LINK_LIBRARIES Boost::convert Boost::included_unit_test_framework COMPILE_FEATURES cxx_std_17)
 endif()
+
+function(boost_exe)
+    cmake_parse_arguments("BOOST_EXE" "" "NAME" "SOURCES;LINK_LIBRARIES;COMPILE_DEFINITIONS;COMPILE_OPTIONS;COMPILE_FEATURES;INCLUDE_DIRECTORIES" ${ARGN})
+
+    add_executable(${BOOST_EXE_NAME} EXCLUDE_FROM_ALL ${BOOST_EXE_SOURCES})
+    target_link_libraries(${BOOST_EXE_NAME} PRIVATE ${BOOST_EXE_LINK_LIBRARIES})
+    target_include_directories(${BOOST_EXE_NAME} PRIVATE ${BOOST_EXE_INCLUDE_DIRECTORIES})
+    target_compile_definitions(${BOOST_EXE_NAME} PRIVATE ${BOOST_EXE_COMPILE_DEFINITIONS})
+    target_compile_options(${BOOST_EXE_NAME} PRIVATE ${BOOST_EXE_COMPILE_OPTIONS})
+    target_compile_features(${BOOST_EXE_NAME} PRIVATE ${BOOST_EXE_COMPILE_FEATURES})
+endfunction()
+
+boost_exe(NAME convert_test_performance SOURCES performance.cpp LINK_LIBRARIES Boost::convert Boost::timer Boost::chrono)
+boost_exe(NAME convert_test_performance_spirit SOURCES performance_spirit.cpp LINK_LIBRARIES Boost::convert INCLUDE_DIRECTORIES ${Boost_SOURCE_DIR} COMPILE_FEATURES cxx_std_17)

--- a/test/jamfile.v2
+++ b/test/jamfile.v2
@@ -24,7 +24,9 @@ project convert_test
         <include>../include
     ;  
 
-exe convert_test_performance : performance.cpp /boost/timer//boost_timer /boost/chrono//boost_chrono ;
+exe convert_test_performance : performance.cpp /boost/timer//boost_timer /boost/chrono//boost_chrono 
+    : [ requires cxx17_hdr_charconv cxx17_structured_bindings cxx17_if_constexpr ]
+      <toolset>gcc:<cxxflags>"-O3 -std=c++17 -Wno-unused-variable -Wno-unused-local-typedefs -Wno-long-long -Wno-nonnull";
 exe convert_test_performance_spirit : performance_spirit.cpp ;
 
 run callable.cpp         :  :  :  : convert_test_callable ;

--- a/test/performance.cpp
+++ b/test/performance.cpp
@@ -15,6 +15,7 @@ int main(int, char const* []) { return 0; }
 #include <boost/convert/printf.hpp>
 #include <boost/convert/strtol.hpp>
 #include <boost/convert/spirit.hpp>
+#include <boost/convert/charconv.hpp>
 #include <boost/convert/lexical_cast.hpp>
 #include <boost/timer/timer.hpp>
 #include <boost/random/mersenne_twister.hpp>
@@ -116,10 +117,10 @@ namespace { namespace local
 
 struct raw_str_to_int_spirit
 {
-    int operator()(char const* str) const
+    int operator()(const my_string str) const
     {
-        char const* beg = str;
-        char const* end = beg + strlen(str);
+        char const* beg = str.begin();
+        char const* end = str.end();
         int      result;
 
         if (boost::spirit::qi::parse(beg, end, boost::spirit::int_, result))
@@ -132,9 +133,25 @@ struct raw_str_to_int_spirit
 
 struct raw_str_to_int_lxcast
 {
-    int operator()(char const* str) const
+    int operator()(const my_string str) const
     {
-        return boost::lexical_cast<int>(str);
+        return boost::lexical_cast<int>(str.begin());
+    }
+};
+
+struct raw_str_to_int_charconv
+{
+    int operator()(const my_string str) const
+    {
+        char const* beg = str.begin();
+        char const* end = str.end();
+        int      result;
+
+        const auto [ptr, ec] = std::from_chars(beg, end, result);
+        if (ptr == end) // ensure the whole string was parsed
+            return result;
+
+        return (BOOST_ASSERT(0), result);
     }
 };
 
@@ -148,7 +165,7 @@ raw_str_to(Converter const& cnv)
 
     for (int t = 0; t < local::num_cycles; ++t)
         for (int k = 0; k < size; ++k)
-            local::sum += cnv(strings[k].c_str());
+            local::sum += cnv(strings[k]);
 
     return timer.value();
 }
@@ -163,7 +180,7 @@ local::str_to(Converter const& try_converter)
 
     for (int t = 0; t < local::num_cycles; ++t)
         for (int k = 0; k < size; ++k)
-            local::sum += boost::convert<Type>(strings[k].c_str(), try_converter).value();
+            local::sum += boost::convert<Type>(strings[k], try_converter).value();
 
     return timer.value();
 }
@@ -245,52 +262,60 @@ main(int, char const* [])
 {
     printf("Started performance tests...\n");
 
-    printf("str-to-int: spirit/strtol/lcast/scanf/stream=%7.2f/%7.2f/%7.2f/%7.2f/%7.2f seconds.\n",
+    printf("str-to-int: spirit/strtol/lcast/scanf/stream/charconv=%7.2f/%7.2f/%7.2f/%7.2f/%7.2f/%7.2f seconds.\n",
            local::str_to<int>(boost::cnv::spirit()),
            local::str_to<int>(boost::cnv::strtol()),
            local::str_to<int>(boost::cnv::lexical_cast()),
            local::str_to<int>(boost::cnv::printf()),
-           local::str_to<int>(boost::cnv::cstream()));
-    printf("str-to-lng: spirit/strtol/lcast/scanf/stream=%7.2f/%7.2f/%7.2f/%7.2f/%7.2f seconds.\n",
+           local::str_to<int>(boost::cnv::cstream()),
+           local::str_to<int>(boost::cnv::charconv()));
+    printf("str-to-lng: spirit/strtol/lcast/scanf/stream/charconv=%7.2f/%7.2f/%7.2f/%7.2f/%7.2f/%7.2f seconds.\n",
            local::str_to<long int>(boost::cnv::spirit()),
            local::str_to<long int>(boost::cnv::strtol()),
            local::str_to<long int>(boost::cnv::lexical_cast()),
            local::str_to<long int>(boost::cnv::printf()),
-           local::str_to<long int>(boost::cnv::cstream()));
-    printf("str-to-dbl: spirit/strtol/lcast/scanf/stream=%7.2f/%7.2f/%7.2f/%7.2f/%7.2f seconds.\n",
+           local::str_to<long int>(boost::cnv::cstream()),
+           local::str_to<long int>(boost::cnv::charconv()));
+    printf("str-to-dbl: spirit/strtol/lcast/scanf/stream/charconv=%7.2f/%7.2f/%7.2f/%7.2f/%7.2f/%7.2f seconds.\n",
            local::str_to<double>(boost::cnv::spirit()),
            local::str_to<double>(boost::cnv::strtol()),
            local::str_to<double>(boost::cnv::lexical_cast()),
            local::str_to<double>(boost::cnv::printf()),
-           local::str_to<double>(boost::cnv::cstream()));
+           local::str_to<double>(boost::cnv::cstream()),
+           local::str_to<double>(boost::cnv::charconv()));
 
-    printf("int-to-str: spirit/strtol/lcast/prntf/stream=%7.2f/%7.2f/%7.2f/%7.2f/%7.2f seconds.\n",
+    printf("int-to-str: spirit/strtol/lcast/prntf/stream/charconv=%7.2f/%7.2f/%7.2f/%7.2f/%7.2f/%7.2f seconds.\n",
            local::to_str<std::string, int>(boost::cnv::spirit()),
            local::to_str<std::string, int>(boost::cnv::strtol()),
            local::to_str<std::string, int>(boost::cnv::lexical_cast()),
            local::to_str<std::string, int>(boost::cnv::printf()),
-           local::to_str<std::string, int>(boost::cnv::cstream()));
-    printf("lng-to-str: spirit/strtol/lcast/prntf/stream=%7.2f/%7.2f/%7.2f/%7.2f/%7.2f seconds.\n",
+           local::to_str<std::string, int>(boost::cnv::cstream()),
+           local::to_str<std::string, int>(boost::cnv::charconv()));
+    printf("lng-to-str: spirit/strtol/lcast/prntf/stream/charconv=%7.2f/%7.2f/%7.2f/%7.2f/%7.2f/%7.2f seconds.\n",
            local::to_str<std::string, long int>(boost::cnv::spirit()),
            local::to_str<std::string, long int>(boost::cnv::strtol()),
            local::to_str<std::string, long int>(boost::cnv::lexical_cast()),
            local::to_str<std::string, long int>(boost::cnv::printf()),
-           local::to_str<std::string, long int>(boost::cnv::cstream()));
-    printf("dbl-to-str: spirit/strtol/lcast/prntf/stream=%7.2f/%7.2f/%7.2f/%7.2f/%7.2f seconds.\n",
+           local::to_str<std::string, long int>(boost::cnv::cstream()),
+           local::to_str<std::string, long int>(boost::cnv::charconv()));
+    printf("dbl-to-str: spirit/strtol/lcast/prntf/stream/charconv=%7.2f/%7.2f/%7.2f/%7.2f/%7.2f/%7.2f seconds.\n",
            local::to_str<std::string, double>(boost::cnv::spirit()),
            local::to_str<std::string, double>(boost::cnv::strtol()(arg::precision = 6)),
            local::to_str<std::string, double>(boost::cnv::lexical_cast()),
            local::to_str<std::string, double>(boost::cnv::printf()(arg::precision = 6)),
-           local::to_str<std::string, double>(boost::cnv::cstream()(arg::precision = 6)));
+           local::to_str<std::string, double>(boost::cnv::cstream()(arg::precision = 6)),
+           local::to_str<std::string, double>(boost::cnv::charconv()(arg::precision = 6)));
 
-    printf("str-to-user-type: lcast/stream/strtol=%.2f/%.2f/%.2f seconds.\n",
+    printf("str-to-user-type: lcast/stream/strtol/charconv=%.2f/%.2f/%.2f/%.2f seconds.\n",
            performance_str_to_type(boost::cnv::lexical_cast()),
            performance_str_to_type(boost::cnv::cstream()),
-           performance_str_to_type(boost::cnv::strtol()));
-    printf("user-type-to-str: lcast/stream/strtol=%.2f/%.2f/%.2f seconds.\n",
+           performance_str_to_type(boost::cnv::strtol()),
+           performance_str_to_type(boost::cnv::charconv()));
+    printf("user-type-to-str: lcast/stream/strtol/charconv=%.2f/%.2f/%.2f/%.2f seconds.\n",
            performance_type_to_str(boost::cnv::lexical_cast()),
            performance_type_to_str(boost::cnv::cstream()),
-           performance_type_to_str(boost::cnv::strtol()));
+           performance_type_to_str(boost::cnv::strtol()),
+           performance_type_to_str(boost::cnv::charconv()));
 
     //[small_string_results
     printf("strtol int-to std::string/small-string: %.2f/%.2f seconds.\n",
@@ -302,9 +327,13 @@ main(int, char const* [])
     printf("stream int-to std::string/small-string: %.2f/%.2f seconds.\n",
            local::to_str<std::string, int>(boost::cnv::cstream()),
            local::to_str<  my_string, int>(boost::cnv::cstream()));
+    printf("charconv int-to std::string/small-string: %.2f/%.2f seconds.\n",
+           local::to_str<std::string, int>(boost::cnv::charconv()),
+           local::to_str<  my_string, int>(boost::cnv::charconv()));
     //]
     performance_comparative(raw_str_to_int_spirit(), boost::cnv::spirit(),       "spirit");
     performance_comparative(raw_str_to_int_lxcast(), boost::cnv::lexical_cast(), "lxcast");
+    performance_comparative(raw_str_to_int_charconv(), boost::cnv::charconv(), "charconv");
 
     return boost::report_errors();
 }

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -134,6 +134,11 @@ struct my_string
 
     static size_t const size_ = 12;
     char storage_[size_];
+
+    friend std::ostream& operator<<(std::ostream& ost, const my_string& str)
+    {
+        return ost << str.c_str();
+    }
 };
 //]
 inline


### PR DESCRIPTION
Added `charconv` to performance test and updated documentation.
I changed performance tests a bit to avoid overhead of calling `strlen` repeatedly as it's already known by `my_string`.