### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,30 @@
+# Copyright René Ferdinand Rivera Morell 2024
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/convert
+    : common-requirements
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/function_types//boost_function_types
+        <source>/boost/lexical_cast//boost_lexical_cast
+        <source>/boost/math//boost_math
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/optional//boost_optional
+        <source>/boost/parameter//boost_parameter
+        <source>/boost/range//boost_range
+        <source>/boost/spirit//boost_spirit
+        <source>/boost/type_traits//boost_type_traits
+        <include>include
+    ;
+
+explicit
+    [ alias boost_convert ]
+    [ alias all : boost_convert example test ]
+    ;
+
+call-if : boost-library convert
+    ;

--- a/build.jam
+++ b/build.jam
@@ -5,26 +5,29 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/function_types//boost_function_types
+    /boost/lexical_cast//boost_lexical_cast
+    /boost/math//boost_math
+    /boost/mpl//boost_mpl
+    /boost/optional//boost_optional
+    /boost/parameter//boost_parameter
+    /boost/range//boost_range
+    /boost/spirit//boost_spirit
+    /boost/type_traits//boost_type_traits ;
+
 project /boost/convert
     : common-requirements
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/function_types//boost_function_types
-        <library>/boost/lexical_cast//boost_lexical_cast
-        <library>/boost/math//boost_math
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/optional//boost_optional
-        <library>/boost/parameter//boost_parameter
-        <library>/boost/range//boost_range
-        <library>/boost/spirit//boost_spirit
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 
 explicit
-    [ alias boost_convert ]
+    [ alias boost_convert : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_convert example test ]
     ;
 
 call-if : boost-library convert
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/convert
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/convert

--- a/build.jam
+++ b/build.jam
@@ -10,7 +10,7 @@ constant boost_dependencies :
     /boost/core//boost_core
     /boost/function_types//boost_function_types
     /boost/lexical_cast//boost_lexical_cast
-    /boost/math//boost_math
+    /boost/math//boost_math_tr1
     /boost/mpl//boost_mpl
     /boost/optional//boost_optional
     /boost/parameter//boost_parameter

--- a/build.jam
+++ b/build.jam
@@ -7,17 +7,17 @@ import project ;
 
 project /boost/convert
     : common-requirements
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/function_types//boost_function_types
-        <source>/boost/lexical_cast//boost_lexical_cast
-        <source>/boost/math//boost_math
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/optional//boost_optional
-        <source>/boost/parameter//boost_parameter
-        <source>/boost/range//boost_range
-        <source>/boost/spirit//boost_spirit
-        <source>/boost/type_traits//boost_type_traits
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/function_types//boost_function_types
+        <library>/boost/lexical_cast//boost_lexical_cast
+        <library>/boost/math//boost_math
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/optional//boost_optional
+        <library>/boost/parameter//boost_parameter
+        <library>/boost/range//boost_range
+        <library>/boost/spirit//boost_spirit
+        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/example/jamfile.v2
+++ b/example/jamfile.v2
@@ -8,6 +8,7 @@ import testing ;
 
 project convert_examples
     : requirements
+        <library>/boost/convert//boost_convert
         <warnings>on
         <toolset>gcc:<warnings>all
         <toolset>msvc:<warnings>all

--- a/test/jamfile.v2
+++ b/test/jamfile.v2
@@ -11,8 +11,9 @@ import-search /boost/config/checks ;
 import testing ;
 import config : requires ;
 
-project convert_test 
+project convert_test
     : requirements
+        <library>/boost/convert//boost_convert
         <warnings>on
         <toolset>icpc:<cxxflags>"-std=c++11"
         <toolset>clang:<cxxflags>"-std=c++11"
@@ -26,9 +27,9 @@ project convert_test
         <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
         <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS
         <include>../include
-    ;  
+    ;
 
-exe convert_test_performance : performance.cpp /boost/timer//boost_timer /boost/chrono//boost_chrono 
+exe convert_test_performance : performance.cpp /boost/timer//boost_timer /boost/chrono//boost_chrono
     : [ requires cxx17_hdr_charconv cxx17_structured_bindings cxx17_if_constexpr ] ;
 exe convert_test_performance_spirit : performance_spirit.cpp ;
 
@@ -42,15 +43,15 @@ run user_type.cpp        :  :  :  : convert_test_user_type ;
 run str_to_int.cpp       :  :  :  : convert_test_str_to_int ;
 run sfinae.cpp           :  :  :  : convert_test_sfinae ;
 run has_member.cpp       :  :  :  : convert_test_has_member ;
-run printf_converter.cpp : 
+run printf_converter.cpp :
       /boost/test/included_unit_test_framework  :  :  : convert_test_printf_converter ;
 run stream_converter.cpp :
       /boost/test/included_unit_test_framework  :  :  : convert_test_stream_converter ;
 
 # these tests require C++17
-run charconv_converter.cpp 
+run charconv_converter.cpp
     : /boost/test//included_unit_test_framework
-    :  
+    :
     : [ requires cxx17_hdr_charconv cxx17_structured_bindings cxx17_if_constexpr ]
       <toolset>gcc:<cxxflags>"-O3 -std=c++17 -Wno-unused-variable -Wno-long-long"
     : convert_test_charconv_converter ;

--- a/test/jamfile.v2
+++ b/test/jamfile.v2
@@ -3,9 +3,13 @@
 # Distributed under the Boost Software License, Version 1.0.
 # See copy at http://www.boost.org/LICENSE_1_0.txt.
 
+require-b2 5.0.1 ;
+
+import-search /boost/config/checks ;
+
 # bring in the rules for testing
 import testing ;
-import ../../config/checks/config : requires ;
+import config : requires ;
 
 project convert_test 
     : requirements


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.